### PR TITLE
docker: fix docker hub login, secrets in examples

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,10 @@ on:
       prebuild:
         description: "Commands to execute before building Docker image"
         type: string
+      dockerhub:
+        description: "Push to Docker Hub (requires secrets to be set)"
+        type: boolean
+        default: false
     secrets:
       DOCKERHUB_USERNAME:
         description: "Docker Hub username"
@@ -55,7 +59,7 @@ jobs:
         uses: docker/setup-buildx-action@aa33708b10e362ff993539393ff100fa93ed6a27 # v3.5.0
 
       - name: "Login to DockerHub"
-        if: secrets.DOCKERHUB_USERNAME != ''
+        if: inputs.dockerhub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           username: "${{ secrets.DOCKERHUB_USERNAME }}"

--- a/workflow-templates/app-prod-deploy.yml
+++ b/workflow-templates/app-prod-deploy.yml
@@ -44,12 +44,16 @@ job:
     name: "Docker"
     uses: hemilabs/actions/.github/workflows/docker.yml@main
     needs: [ "prepare" ]
+    permissions:
+      contents: read
+      packages: write # Needed to push to the GitHub Container Registry
     with:
       version: "${{ needs.prepare.outputs.version }}"
       # context: "${{ github.workspace }}
       # platforms: "linux/amd64"
       # file: "${{ github.workspace }}/Dockerfile"
       # prebuild-commands: "echo 'hello world'"
+      dockerhub: true
       tags: | # TODO: Change image names
         hemilabs/app:latest
         hemilabs/app:${{ needs.prepare.outputs.tag }}
@@ -57,12 +61,17 @@ job:
         ghcr.io/hemilabs/app:latest
         ghcr.io/hemilabs/app:${{ needs.prepare.outputs.tag }}
         ghcr.io/hemilabs/app:${{ github.sha }}
+    secrets:
+      DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}"
+      DOCKERHUB_PASSWORD: "${{ secrets.DOCKERHUB_PASSWORD }}"
 
   # Deploy to Kubernetes cluster
   deploy:
     name: "Deploy to prod"
     uses: hemilabs/actions/.github/workflows/deploy-kustomize.yml@main
     needs: [ "prepare", "docker" ]
+    permissions:
+      contents: read
     with:
       namespace: "app" # TODO: Use correct namespace
       kustomize: "${{ github.workspace }}/kubernetes/kustomize/overlays/prod/" # TODO: Use correct kustomize path

--- a/workflow-templates/app-staging-deploy.yml
+++ b/workflow-templates/app-staging-deploy.yml
@@ -14,21 +14,30 @@ job:
   docker:
     name: "Docker"
     uses: hemilabs/actions/.github/workflows/docker.yml@main
+    permissions:
+      contents: read
+      packages: write # Needed to push to the GitHub Container Registry
     with:
       version: "${{ github.sha }}"
       # context: "${{ github.workspace }}
       # platforms: "linux/amd64"
       # file: "${{ github.workspace }}/Dockerfile"
       # prebuild-commands: "echo 'hello world'"
+      dockerhub: true
       tags: | # TODO: Change image names
         hemilabs/app:${{ github.sha }}
         ghcr.io/hemilabs/app:${{ github.sha }}
+    secrets:
+      DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}"
+      DOCKERHUB_PASSWORD: "${{ secrets.DOCKERHUB_PASSWORD }}"
 
   # Deploy to Kubernetes cluster
   deploy:
     name: "Deploy to staging"
     uses: hemilabs/actions/.github/workflows/deploy-kustomize.yml@main
     needs: [ "docker" ]
+    permissions:
+      contents: read
     with:
       namespace: "app" # TODO: Use correct namespace
       kustomize: "${{ github.workspace }}/kubernetes/kustomize/overlays/staging/" # TODO: Use correct kustomize path


### PR DESCRIPTION
Fix Docker Hub login being optional, 'secrets' cannot be used in `if:`.
Additionally, fix permissions and DOCKERHUB secrets in templates/examples.
