### PR TITLE
deploy-kustomize: support multiple images, add preapply script input

### DIFF
--- a/.github/workflows/deploy-kustomize.yml
+++ b/.github/workflows/deploy-kustomize.yml
@@ -11,7 +11,7 @@ on:
         type: string
         required: true
       image:
-        description: "Docker image to deploy (changed with 'kustomize set image')"
+        description: "Docker image(s) to deploy (changed with 'kustomize set image', separated by whitespace)"
         type: string
         required: true
       environment-name:
@@ -19,6 +19,9 @@ on:
         type: string
       environment-url:
         description: "GitHub Deployment environment URL"
+        type: string
+      preapply:
+        description: "Commands to execute before applying"
         type: string
     secrets:
       KUBECONFIG:
@@ -51,6 +54,11 @@ jobs:
       - name: "Install Kustomize"
         uses: imranismail/setup-kustomize@2ba527d4d055ab63514ba50a99456fc35684947f # v2.1.0
 
+      - name: "Pre-apply"
+        if: inputs.preapply != ''
+        working-directory: "${{ inputs.kustomize }}"
+        run: "${{ inputs.preapply }}"
+
       - name: "Apply Kubernetes manifests"
         working-directory: "${{ inputs.kustomize }}"
         env:
@@ -58,6 +66,8 @@ jobs:
           IMAGE: "${{ inputs.image }}"
         run: |
           kustomize edit set namespace "$NAMESPACE"
-          kustomize edit set image "$IMAGE"
+          for image in $IMAGE; do
+            kustomize edit set image "$image"
+          done
           kustomize build .
           kubectl apply -k .


### PR DESCRIPTION
Add support for multiple images (separated by whitespace) and add pre-apply script input to deploy-kustomize workflow.
