### PR TITLE
Add 'docker-registry-secret' workflow

### DIFF
--- a/.github/workflows/docker-registry-secret.yml
+++ b/.github/workflows/docker-registry-secret.yml
@@ -1,0 +1,70 @@
+name: "Deploy"
+on:
+  workflow_call:
+    inputs:
+      secret-name:
+        description: "Kubernetes secret name"
+        type: string
+        default: "dockerhub"
+      namespace:
+        description: "Kubernetes namespace in which to create the secret"
+        type: string
+        required: true
+      docker-server:
+        description: "Docker registry server"
+        type: string
+        default: "https://index.docker.io/v1/"
+    secrets:
+      KUBECONFIG:
+        description: "Kubeconfig file contents"
+        required: true
+      KUBECONFIG_CONTEXT:
+        description: "The name of the kubectl context to use"
+        required: true
+      DOCKER_USERNAME:
+        description: "Username for Docker registry authentication"
+        required: true
+      DOCKER_EMAIL:
+        description: "Email for Docker registry"
+        required: true
+      DOCKER_PASSWORD:
+        description: "Password for Docker registry authentication"
+        required: true
+
+jobs:
+  registry-secret:
+    name: "Registry secret"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: "Install kubectl"
+        uses: azure/k8s-set-context@27bfb387305b8f0ab5495d692e4a3304db7d0669 # v4.0.0
+        with:
+          method: "kubeconfig"
+          kubeconfig: "${{ secrets.KUBECONFIG }}"
+          context: "${{ secrets.KUBECONFIG_CONTEXT }}"
+
+      - name: "Create docker-registry secret"
+        working-directory: "${{ inputs.kustomize }}"
+        env:
+          SECRET_NAME: "${{ inputs.secret-name }}"
+          NAMESPACE: "${{ inputs.namespace }}"
+          DOCKER_SERVER: "${{ inputs.docker-server }}"
+          DOCKER_USERNAME: "${{ secrets.DOCKER_USERNAME }}"
+          DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
+          DOCKER_EMAIL: "${{ secrets.DOCKER_EMAIL }}"
+        run: |
+          # Create Docker Hub secret
+          if ! kubectl get secret "$SECRET_NAME" --namespace="$NAMESPACE" > /dev/null; then
+            echo "Creating Docker registry secret..."
+            kubectl create secret docker-registry "$SECRET_NAME" \
+              --docker-server="$DOCKER_SERVER" \
+              --docker-username="$DOCKER_USERNAME" \
+              --docker-password="$DOCKER_PASSWORD" \
+              --docker-email="$DOCKER_EMAIL" \
+              --namespace="$NAMESPACE"
+          fi


### PR DESCRIPTION
Add GitHub Actions workflow that can be used to deploy a 'docker-registry' secret to a Kubernetes cluster with a given name in the specified namespace.
