### PR TITLE
Add prefix 'js-checks' to workflow

### DIFF
--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: js-checks-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This PR adds the prefix `js-checks` to the concurrency group name for that workflow. This is because the name we were using is the default name we use on many other repos, so when those try to use this workflow, Github gives an error