### PR TITLE
Update and pin GitHub Actions versions

### DIFF
--- a/.github/workflows/deploy-kustomize.yml
+++ b/.github/workflows/deploy-kustomize.yml
@@ -46,10 +46,10 @@ jobs:
       url: "${{ inputs.environment-url }}"
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: "Install kubectl"
-        uses: azure/k8s-set-context@27bfb387305b8f0ab5495d692e4a3304db7d0669 # v4.0.0
+        uses: azure/k8s-set-context@212a19233d93f03eceaac31ae5a1d1acf650b6ef # v4.0.1
         with:
           method: "kubeconfig"
           kubeconfig: "${{ secrets.KUBECONFIG }}"

--- a/.github/workflows/docker-registry-secret.yml
+++ b/.github/workflows/docker-registry-secret.yml
@@ -43,10 +43,10 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: "Install kubectl"
-        uses: azure/k8s-set-context@27bfb387305b8f0ab5495d692e4a3304db7d0669 # v4.0.0
+        uses: azure/k8s-set-context@212a19233d93f03eceaac31ae5a1d1acf650b6ef # v4.0.1
         with:
           method: "kubeconfig"
           kubeconfig: "${{ secrets.KUBECONFIG }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,13 +54,13 @@ jobs:
       packages: write # Needed to push to GitHub Container Registry
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: "Setup QEMU"
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
 
       - name: "Setup Docker Buildx"
-        uses: docker/setup-buildx-action@aa33708b10e362ff993539393ff100fa93ed6a27 # v3.5.0
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
       - name: "Login to DockerHub"
         if: inputs.dockerhub
@@ -86,7 +86,7 @@ jobs:
         run: "${{ inputs.prebuild }}"
 
       - name: "Build and push"
-        uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: "${{ inputs.context }}"
           platforms: "${{ inputs.platforms }}"

--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
       - uses: hemilabs/actions/setup-node-env@main
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
       - uses: hemilabs/actions/setup-node-env@main

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,11 +21,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
       - uses: hemilabs/actions/setup-node-env@main
       - run: npm run --if-present prepublishOnly
-      - uses: JS-DevTools/npm-publish@v3
+      - uses: JS-DevTools/npm-publish@9ff4ebfbe48473265867fb9608c047e7995edfa3 # v3.1.1
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/setup-node-env/action.yml
+++ b/setup-node-env/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
       with:
         cache: npm
         cache-dependency-path: "**/package-lock.json"

--- a/workflow-templates/app-prod-deploy.yml
+++ b/workflow-templates/app-prod-deploy.yml
@@ -26,7 +26,7 @@ job:
       version_type: "${{ steps.version.outputs.type }}"
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: "Retrieve build data"
         id: "data"


### PR DESCRIPTION
Update the GitHub Actions used in this repository to the latest versions.
Additionally, this pins GitHub Actions in workflows introduced in #6 to commit hashes for security reasons.