### PR TITLE
Remove concurrency settings from js-checks

### DIFF
--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -8,10 +8,6 @@ on:
         default: "['']"
         type: string
 
-concurrency:
-  group: js-checks-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
-
 jobs:
   run-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove `concurrency` settings from the reusable workflow `js-checks.yml`.

Placing `concurrency` settings in reusable workflow often causes issues, especially with `${{ github.workflow }}` (#7).
Instead, concurrency should be managed by the workflows that use `js-checks.yml`.
