### PR TITLE
Restrict token permissions in js-checks and npm-publish workflows

### DIFF
--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   run-checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: hemilabs/actions/setup-node-env@main
@@ -24,6 +26,8 @@ jobs:
       - run: npm run --if-present --include-workspace-root --workspaces build
   run-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: hemilabs/actions/setup-node-env@main

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   publish-to-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: hemilabs/actions/setup-node-env@main


### PR DESCRIPTION
Restrict the permissions granted to the GitHub Actions `GITHUB_TOKEN` in the `js-checks` and `npm-publish` workflows, allowing only `contents: read` (which is required for `actions/checkout`).