### PR TITLE
Add fetch-depth: 0 on actions/checkout

### DIFF
--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -19,6 +19,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: hemilabs/actions/setup-node-env@main
       - run: npm run --if-present format:check
       - run: npm run --if-present lint
@@ -30,6 +32,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
       - uses: hemilabs/actions/setup-node-env@main
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -7,6 +7,10 @@ name: JS Checks
 on:
   workflow_call:
     inputs:
+      fetch-depth:
+        description: Number of commits to fetch. 0 indicates all history for all branches and tags.
+        default: 1
+        type: number
       node-versions:
         description: Array of Node versions to test with (JSON string)
         default: "['']"
@@ -20,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ inputs.fetch-depth }}
       - uses: hemilabs/actions/setup-node-env@main
       - run: npm run --if-present format:check
       - run: npm run --if-present lint
@@ -33,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-            fetch-depth: 0
+          fetch-depth: ${{ inputs.fetch-depth }}
       - uses: hemilabs/actions/setup-node-env@main
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,6 +6,11 @@ name: NPM Publish
 
 on:
   workflow_call:
+    inputs:
+      fetch-depth:
+        description: Number of commits to fetch. 0 indicates all history for all branches and tags.
+        default: 1
+        type: number
     secrets:
       NPM_TOKEN:
         required: true
@@ -18,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ inputs.fetch-depth }}
       - uses: hemilabs/actions/setup-node-env@main
       - run: npm run --if-present prepublishOnly
       - uses: JS-DevTools/npm-publish@v3

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: hemilabs/actions/setup-node-env@main
       - run: npm run --if-present prepublishOnly
       - uses: JS-DevTools/npm-publish@v3


### PR DESCRIPTION
Some workflows may require more than the tip of the target branch, such as the ones using `lerna` to find out if there has been changes since the last merge in dedicated subrepos.

After discussing with Gabriel and Joshua, this PR adds `fetch-depth: 0` so that's no longer a problem