### PR TITLE
Add support for publishing packages using provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -28,4 +29,5 @@ jobs:
       - run: npm run --if-present prepublishOnly
       - uses: JS-DevTools/npm-publish@9ff4ebfbe48473265867fb9608c047e7995edfa3 # v3.1.1
         with:
+          provenance: true
           token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR updates the `npm-publish` action to add the flag `--provenance` when publishing a package. By adding provenance to our publish, we can link each version to the workflow and commit to publishing, increasing the security of our supply chain builds.   
Further reading [here](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)

You can check the [npm docs](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions) that shows the change implemented here, and the option for the [JS-DevTools/npm-publish action](https://github.com/JS-DevTools/npm-publish?tab=readme-ov-file#action-usage)

I already run a test publishing with `provenance` [in the crypto-shortener package](https://github.com/hemilabs/crypto-shortener/pull/5), which prints the following automatically in the README on [npm](https://www.npmjs.com/package/crypto-shortener)

<img width="914" alt="image" src="https://github.com/user-attachments/assets/597b410f-21b3-4a11-9216-d6cbd76b0aa0" />

With the change of this PR, all packages publishing through this action will automatically publish with `provenance`, no further changes are needed in each package.