### PR TITLE
docs: add actions and security guidelines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,24 @@
+#
 # This file exists to designate certain reviewers for certain areas of the
 # repository. This allows us to enhance security measures, streamline reviews
 # and help automate review requests.
+#
+# Each team should be responsible for maintaining the workflows or actions they
+# contribute to this repository. When adding files, please add your team as a
+# code owner, unless otherwise decided.
+#
+# Additionally, for security purposes, all changes require a sign-off from a
+# member of the @hemilabs/devops or @hemilabs/secops teams.
+#
 
 # This is the default owner for all files in this repository.
-# Core Engineering and Joshua Sing are responsible for all files in this repository.
-* @hemilabs/dev @joshuasing
+* @hemilabs/devops
+
+# Documentation
+/docs/guidelines.md  @hemilabs/app-devs @hemilabs/dev @hemilabs/devops
+/docs/security.md    @hemilabs/secops
+
+# Application Engineering
+/.github/workflows/js-checks.yml    @hemilabs/app-devs
+/.github/workflows/npm-publish.yml  @hemilabs/app-devs
+/setup-node-env/                    @hemilabs/app-devs

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -1,0 +1,201 @@
+# Actions Guidelines
+
+> Last updated: **April 24th, 2025**
+
+This document outlines a shared set of guidelines for creating and maintaining GitHub Actions files for Hemi Labs.
+
+*These guidelines are currently a work-in-progress proposal and need review and agreement from all engineering teams at
+Hemi Labs.*
+
+---
+
+## 1. Reusable actions and workflows
+
+The [`hemilabs/actions`](https://github.com/hemilabs/actions/) repository is the primary repository for GitHub Actions
+and workflows.
+
+- Workflows or actions used in multiple repositories should be placed here, unless there's a specific reason not
+  to (e.g., internal, or environment-specific logic).
+- Aim to make actions and workflows configurable and well-documented to allow reuse.
+- Breaking changes to shared actions or workflows should be discussed prior to being made to avoid unexpected issues in
+  consuming projects.
+
+### 1.1. Versioning
+
+The `hemilabs/actions` repository uses tagged releases, following Semantic Versioning. Consumers of actions or workflows
+from `hemilabs/actions` should pin the action/workflows to a `vX.X` or `vX.X.X` tag to avoid unexpected or unreviewed
+changes.
+
+When breaking changes may need to be made to a certain action or workflow, an appropriate version bump must be made to
+avoid disrupting existing consumers.
+
+### 1.2. Reviews
+
+All changes made to the `hemilabs/actions` repository should be reviewed by two team members from the team that owns
+the updated files. When multiple teams are owners, at least one reviewer from each team should approve the changes to
+ensure alignment and avoid surprises.
+
+Additionally, for security purposes, all changes require a sign-off from a member of the `@hemilabs/devops` or
+`@hemilabs/secops` teams.
+
+### 1.3. Ownership
+
+Each team should be responsible for maintaining the workflows or actions they contribute to this repository.
+When contributing workflows or actions, add your team as a [code owner](../.github/CODEOWNERS), unless agreed upon. This
+helps ensure appropriate review coverage and accountability.
+
+## 2. Security
+
+Please see [security guidelines](security.md).
+
+## 3. Style and formatting
+
+All workflows and actions must follow consistent formatting rules to improve readability and maintainability.
+Consistency also helps reduce unnecessary diff noise during reviews.
+
+- Format YAML files using [`prettier`](https://prettier.io/) with the default config.
+- Use the `.yml` extension for YAML files (not `.yaml`).
+- Indent using 2 spaces consistently.
+- Add inline comments where logic may not be obvious.
+
+## 4. Workflows
+
+- Repository-specific workflows: `.github/workflows/`
+- Workflow templates for reuse: `.github/workflow-templates/`
+- Reusable workflows: `hemilabs/actions/.github/workflows/`
+
+Refer to [Reusable actions and workflows](#1-reusable-actions-and-workflows) for reusable workflows.
+
+### 4.1. File name
+
+Use lowercase kebab-case file names with the `.yml` extension. Keep names short but descriptive.
+
+The file name should roughly match the workflow name.
+
+**Examples:**
+
+- `go.yml`: Build, lint and test a Go project.
+- `js.yml`: Build, lint and test a JavaScript project.
+- `npm-publish.yml`: Publish an NPM project.
+- `kustomize-deploy.yml`: Deploy using Kustomize.
+
+### 4.2. Workflow Name
+
+Workflow names should be a short, clear label - usually a noun (e.g. "Go" or "JavaScript") - that describes the type of
+project or task the workflow is for.
+
+```yaml
+name: "Go"
+name: "JavaScript"
+name: "Deploy"
+```
+
+Workflow names appear with the job name in the GitHub UI as `<workflow> / <job>`, so both should be readable and
+descriptive together.
+
+**Good examples:**
+
+- `Go / Build`
+- `JavaScript / Lint`
+- `Deploy / Staging`
+
+### 4.3. Jobs
+
+Job names should normally be verbs to describe the action being taken.
+
+**Examples:**
+
+- `Build` - Builds the project.
+- `Test` - Runs tests.
+- `Deploy` - Deploys to an environment.
+- `Lint` - Runs linters.
+- `Publish` - Publish a package.
+
+For context-specific jobs (e.g. when using matrix), consider using parentheses:
+
+- `Build (${{ env.GO_VERSION }})` -> `Go / Build (1.24.2)`
+- `Deploy (staging)`
+
+### 4.5. Steps
+
+Jobs consist of steps, each of which should be:
+
+- Clear in intent.
+- Named descriptively.
+- Ordered logically.
+- Commented if they contain non-obvious logic.
+
+It is good practice to use step names that clearly describe their function, improving maintainability and readability.
+
+Step keys should be ordered as:
+
+- `name`
+- `id`
+- `if`
+- `shell`
+- `working-directory`
+- `env`
+- `uses` / `run`
+- `with`
+
+Ordering keys consistently improves readability and reduces unnecessary diffs during reviews.
+
+```yaml
+    - name: "Checkout repository"
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        path: "./example/"
+
+    - name: "Read version"
+      id: version
+      run: |
+        VERSION=$(cat version)
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: "Install dependencies"
+      working-directory: "example/"
+      env:
+        GO_VERSION: "1.24.x"
+        TEST_VERSION: "${{ steps.version.outputs.version }}"
+      run: make deps
+```
+
+## 5. Actions
+
+- Repository-specific actions: `.github/actions/`
+- Reusable actions: `hemilabs/actions/`
+
+Refer to [Reusable actions and workflows](#1-reusable-actions-and-workflows) for reusable actions.
+
+### 5.1. Composite Actions
+
+When multiple steps are commonly reused, it may be helpful to bundle them into a composite action.
+
+- Prefer composite actions for reusing workflow logic.
+- Keep composite actions minimal and focused on a single responsibility, for example, installing a tool or setting up an
+  environment.
+- Document inputs, outputs, and usage clearly in a `README.md` file.
+
+### 5.2. Custom Actions
+
+When it is necessary to implement functionality beyond what is possible in a workflow or composite action, a custom
+JavaScript or Docker-based action could be created.
+
+Custom actions introduce more maintenance overhead and complexity (especially Docker-based). Use only when composite
+actions are insufficient.
+
+## 6. Collaboration
+
+To encourage clarity and consistency across all actions and workflows:
+
+- **Propose early, discuss openly** - When introducing or updating shared actions or workflows, open a pull request
+  early and use it as a space for open discussion.
+- **Align on patterns** - Where multiple valid approaches exist, follow established patterns unless there's a strong
+  and documented reason to diverge.
+- **Add documentation** - Ensure changes and usage are well-documented, making it easy for teams to understand what
+  changed, why it changed, and how to adopt it.
+
+These guidelines are intended to support consistency and maintainability across teams. Feedback is welcome, and
+improvements to these guidelines are always encouraged.
+
+To suggest changes to these guidelines, feel free to open an issue, pull request, or send a message in Slack.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,187 @@
+# Actions Security Guidelines
+
+> Last updated: **April 24th, 2025**
+
+## Purpose
+
+These guidelines outline security best practices for GitHub Actions workflows and actions used by Hemi Labs.
+
+---
+
+## Key Principles
+
+- **Least privilege** - Always apply the principle of least privilege to workflows, actions and secrets. Limit the scope
+  of permissions and access to only what is strictly necessary.
+
+- **Minimise exposure** - Use minimally scoped secrets and access tokens, reduce the amount of secrets accessible by a
+  workflow, and avoid logging secrets or writing them to files.
+
+- **Integrity and trust** - Use only trusted actions and dependencies, verify their integrity and regularly audit and
+  update them.
+
+---
+
+## 1. Workflows
+
+## 1.1. Secrets
+
+- **Never hardcode secrets** - Always store sensitive data in GitHub Actions secrets and reference them securely within
+  workflows.
+
+- **Limit secret access** - Only expose secrets to the workflows that need them. When possible, avoid using global
+  secrets if specific jobs do not require them. Repository-level secrets or environment secrets can be created to
+  further limit access to the secrets, which can then have lower scope.
+
+- **Rotate secrets regularly** - Secrets should be rotated periodically to reduce their lifetime and the potential risk
+  of a compromised secret being used.
+
+- **Mask secrets** - Ensure secrets are never logged or exposed during workflow executions. GitHub automatically masks
+  secrets, however they should still never be printed or written to files.
+
+## 1.2. `GITHUB_TOKEN` permissions
+
+- **Use minimal permissions** - Grant the least amount of permissions required to perform a job. For example, jobs that
+  build and test a project rarely require any permissions other than `contents: read`.
+
+- **Always override the default permissions** - Workflows should always specify the permissions for a job or workflow.
+  The base permissions should always be `contents: read`.
+
+Use the `permissions:` key at the workflow or job level to explicitly declare the permissions needed. Avoid relying on
+the default GitHub token permissions.
+
+A full list of permissions can be found
+on [GitHub's documentation: Controlling permissions for GITHUB_TOKEN](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token).
+
+```yaml
+permissions:
+  contents: read
+  id-token: write # Only when using OIDC.
+```
+
+## 1.3. Actions
+
+- **Use trusted actions** - Prefer actions from trusted sources, such as official GitHub actions or those hosted in the
+  `hemilabs/actions` repository. Always review third-party (including GitHub) actions prior to using them.
+
+- **Check transitive dependencies** - Actions, especially composite actions, may depend on other actions. Such
+  dependencies should be reviewed (usually possible by viewing the `action.yml` file within the action repository) and
+  ensured that all transitive dependencies are pinned to commit hashes.
+
+- **Pin actions to commit hashes** - Third-party actions **must be pinned to commit hashes** to avoid unexpected
+  changes. Only commit hashes for released tags should be used, and a comment should be added to the end of the line to
+  document the release that is in use. **Never pin to `latest`, branches or tags.** The only exception to this rule is
+  actions within `hemilabs/actions`, which should be pinned to a `vX.X` or `vX.X.X` tag.
+
+```yaml
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+```
+
+---
+
+## 2. Actions
+
+## 2.1. Secrets
+
+- **Consuming secrets** - If an action requires secrets, ensure they are passed securely through GitHub Actions secrets.
+- **Mask sensitive data** - Ensure sensitive data is always masked in logs to avoid accidental exposure.
+
+## 2.2. Design
+
+- **Avoid external dependencies unless necessary** - When creating a custom action, avoid unnecessary dependencies to
+  minimise possible attack surface.
+
+- **Pin dependencies** - For composite actions, all third-party actions **must be pinned to commit hashes**. Similarly,
+  all JavaScript dependencies should be pinned to avoid unexpected and unreviewed changes.
+
+- **Use minimal and pinned DOcker images** - If using Docker-based actions:
+  - Use minimal, actively maintained Docker image based on a trusted and well-known base (e.g. `scratch`, `alpine` or
+    `debian:slim`) to reduce the surface area and potential vulnerabilities.
+  - Pin Docker images by `sha256` digest rather than tags to ensure immutability and unexpected changes.
+
+```Dockerfile
+FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
+```
+
+---
+
+## 3. General Best Practices
+
+### 3.1. Monitoring
+
+- **Audit logs** - Regularly audit the GitHub Actions logs for any signs of unusual behaviour or errors, especially in
+  workflows that involve sensitive data or production deployments.
+
+### 3.2. Minimise workflow triggers
+
+- **Control workflow triggers** - Be specific with workflow triggers. For example, avoid unnecessary workflow executions
+  for every push to any branch. Limit triggers to the events that are necessary for the workflow.
+
+```yaml
+on:
+  push:
+    branches: [ "main" ]
+```
+
+- **Restrict sensitive workflow runs** - Restrict sensitive workflows, especially deployment workflows, to only trusted
+  branches with strict access control to prevent malicious triggers from unauthorised users. Additionally, where
+  possible, use GitHub environments with rulesets configured to apply additional security rules for the deployment.
+
+### 3.3. Dependency management
+
+- **Automate dependency scanning** - When appropriate, use tools such as Dependabot or Renovate bot to automatically
+  monitor dependencies. This allows teams to be notified when a dependency update is available, so that the update can
+  be reviewed and then used.
+
+### 3.4 Script safety
+
+- **Avoid untrusted input in scripts** - Never interpolate untrusted input directly into shell commands. Always validate
+  and sanitise inputs from users, pull requests, or other sources before use.
+
+- **Beware of `${{ }}` expression injection** - Inputs from `${{ github.event.* }}` and other contexts may be
+  attacker-controlled (e.g. pull request titles, branch names, commit messages, inputs, etc.). Do not interpolate these
+  directly into shell scripts without validation.
+
+```yaml
+# ❌ Vulnerable to injection
+run: |
+  echo "PR title: ${{ github.event.pull_request.title }}"
+
+# ✅ Safer
+env:
+  PR_TITLE: "${{ github.event.pull_request.title }}"
+run: |
+  echo "PR title: $PR_TITLE"
+```
+
+- **Avoid `eval`, backticks, or unescaped interpolation** - Avoid using `eval`, backticks, or dynamically constructed
+  commands unless absolutely necessary. These patterns are highly prone to injection vulnerabilities.
+
+- **Avoid `curl | sh`-like patterns** - Instead, download the scripts and preferably validate the checksum prior to
+  execution.
+
+```yaml
+# ❌ Dangerous
+run: curl -sSL https://example.com/install.sh | sh
+
+# ✅ Safer
+run: |
+  curl -sSL https://example.com/install.sh -o install.sh
+  echo "$INSTALLSH_CHECKSUM" | sha256sum --check -
+  chmod +x install.sh
+  ./install.sh
+```
+
+---
+
+## 4. Reporting issues
+
+If you notice a potential security issue in an action or workflow, raise it immediately with your team lead or via
+internal security channels. Quick detection and response helps us protect from potential attacks.
+
+## 5. Collaboration
+
+- **Collaborate with SecOps** - Work closely with Security Operations (SecOps), currently acting as the security
+  point-of-contact, to ensure workflows and actions comply with security best practices.
+
+- **Feedback and improvements** - Continuous improvement of our security practices is crucial. If you have feedback or
+  suggestions for these guidelines, please feel free to create an issue or start a discussion internally.


### PR DESCRIPTION
Add initial draft for two documents:
 - `/docs/guidelines.md`: Outlines a shared set of guidelines for creating and maintaining GitHub Actions files at Hemi Labs.
 - `/docs/security.md`: Outlines security best practices for GitHub Actions workflows and actions used by Hemi Labs.
 
The purpose of these guidelines is to support consistency, maintainability, and security across all our GitHub Actions workflows and actions. These guidelines are currently a work-in-progress proposal based on best practices and our previous discussions, and will require review and consensus from all engineering teams before being merged.

Feedback and suggestions are completely welcome - please feel free to make comments to discuss or suggest changes. Since these documents should be followed consistently, it's important that we agree on the contents prior to merging.

This also updates the CODEOWNERS file to align with the guidelines and our previous discussions.