### PR TITLE
Bump setup-node action version

### DIFF
--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -31,7 +31,7 @@ jobs:
           version: "${{ env.PNPM_VERSION }}"
 
       - name: "Setup Node"
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: ".nvmrc"
           check-latest: true

--- a/setup-node-env/action.yml
+++ b/setup-node-env/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         cache: npm
         cache-dependency-path: "**/package-lock.json"


### PR DESCRIPTION
I noticed when building the portal the following warning:

> Failed to save: Unable to reserve cache with key node-cache-Linux-x64-npm-219d4f95206594c49b141902002f5752363de7f4b2ee4f6f1226b16d95003cbb, another job may be creating this cache. More details: This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset

The `actions/setup-node` action was using a deprecated version of `actions/cache`. This PR bumps the `setup-node` action so it uses the newest version. I checked the releases (it's just 3 commits).