### PR TITLE
all: add renovate-bot config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,4 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["local>hemilabs/actions:renovate.json5"],
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,28 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:recommended",
+    ":configMigration",
+    "schedule:weekly",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionsDigests",
+    ":pinAllExceptPeerDependencies",
+    ":enableVulnerabilityAlerts",
+    "preview:dockerVersions",
+    "preview:dockerCompose",
+  ],
+  commitMessagePrefix: "all:",
+  commitMessageAction: "update",
+  commitMessageTopic: "{{depName}}",
+  labels: ["type: dependencies"],
+  packageRules: [
+    {
+      matchDatasources: ["docker"],
+      commitMessageTopic: "image {{depName}}",
+    },
+    {
+      matchDatasources: ["helm"],
+      commitMessageTopic: "chart {{depName}}",
+    },
+  ],
+}


### PR DESCRIPTION
Add a configuration preset (reusable) for Renovate bot and use it in this repository.

This configuration will:
- Create dependency update pull requests weekly, on Mondays.
- Pin Docker images to SHA256 digests.
- Pin GitHub Actions to SHA1 commit hashes.
- Pin all NPM dependencies except peer dependencies (this can be overridden per repository if necessary)
- Enable vulnerability alerts.
- Create pull request titles/commit messages in the format: `all: update X to v1.2.3` (e.g. `all: update image golang to 1.24.4-alpine3.21`, `all: update actions/checkout action to v4.5.0`)
- Add label to pull requests: `type: dependencies`

This configuration is a base, and should be improved later as needed - it can also be reused in other repositories (with optional overrides) in the future if we want.