### PR TITLE
github: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,5 @@
 # and help automate review requests.
 
 # This is the default owner for all files in this repository.
-# Core Engineering and Joshua Sing are responsible for all files in this repository.
-* @hemilabs/dev @joshuasing
+# Protocol Engineering and SecOps are responsible for all files in this repository.
+* @hemilabs/eng-protocol @hemilabs/security


### PR DESCRIPTION
**Summary**
Update team names in CODEOWNERS

**Changes**
- Rename `@hemilabs/dev` to `@hemilabs/eng-protocol`
- Add `@hemilabs/security`