### PR TITLE
Add workflow for trusted deployments

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Hemi Labs, Inc.
+# Copyright (c) 2024-2025 Hemi Labs, Inc.
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 


### PR DESCRIPTION
This PR adds a workflow for using [Trusted deployments](https://docs.npmjs.com/trusted-publishers#supported-cicd-providers) for Npm publish.

It's very similar to [npm publish](https://github.com/hemilabs/actions/blob/main/.github/workflows/npm-publish.yml) with 3 main differences:

- provenance is not needed (it's by default)
- The NPM token must not be passed. That's why I am not using the current npm implementation
- It doesn't require using `JS-DevTools` (removing dependencies 🎉 )

These 2 jobs will co-exist while we migrate packages to use this deployment (packages need to be updated to node 24). But eventually, I think we can just remove the `npm-publish.yml` job, and use this new one

I was already able to use this setup with [viem-erc20](https://www.npmjs.com/search?q=viem-erc20)

<img width="650" height="167" alt="image" src="https://github.com/user-attachments/assets/fb7e3202-a29f-4db3-a80e-da4462382aff" />


(Notice the OIDC)