### PR TITLE
feat: add notify-deploy-to-slack action

### DIFF
--- a/notify-deploy-to-slack/action.yml
+++ b/notify-deploy-to-slack/action.yml
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+
+name: Notify to Slack
+
+author: Gabriel Montes
+
+description: Send a notification to Slack using incoming webhooks
+
+inputs:
+  app-name:
+    description: "The app being deployed"
+    required: true
+  environment:
+    description: "The deployment environment"
+    required: true
+  reference:
+    description: "Additional reference to add to the notification"
+    required: false
+    default: ""
+  slack-mention:
+    description: "The mention to include in the message"
+    default: <!here>
+  slack-webhook-url:
+    description: "The Slack incoming webhook URL"
+    required: true
+  status:
+    description: "The deployment status"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+      with:
+        webhook: ${{ inputs.slack-webhook-url }}
+        webhook-type: incoming-webhook
+        payload: |
+          {
+            "text": ${{ toJSON(join(env.PAYLOAD_TEXT, '\n')) }}
+          }
+      env:
+        PAYLOAD_TEXT: |
+          ${{ format('{0} Deployment of {1} to {2} {3}', inputs.slack-mention, inputs.app-name, inputs.environment, inputs.status) }}
+          ${{ inputs.reference }}
+
+branding:
+  color: blue
+  icon: bell


### PR DESCRIPTION
## What

Adds a `notify-deploy-to-slack` composite action that sends a deployment
notification to Slack via an incoming webhook.

## Why

This implementation comes from the now-**archived**
[`bloq/actions`](https://github.com/bloq/actions) repository, which we discovered
we are still depending on. Since that repo is archived (no longer maintained and
could be removed at any time), we should stop relying on it and bring the actions
we use into `hemilabs/actions` instead. This PR ports the Slack deploy
notification action as part of that migration.

## Changes

- New `notify-deploy-to-slack/action.yml`, ported from `bloq/actions`.
- Pins `slackapi/slack-github-action` to `v3.0.3` (the bloq version was `v1.27.1`).
  v2 changed the API in a breaking way, so the step was adapted: the webhook URL
  now goes through the `webhook` input and the new required `webhook-type:
  incoming-webhook` input is set, instead of the old `SLACK_WEBHOOK_URL` env var.
  The JSON payload and message format are otherwise unchanged.


Related to https://github.com/hemilabs/ui-monorepo/issues/1999

🤖 Generated with [Claude Code](https://claude.com/claude-code)